### PR TITLE
Feature/add activity table

### DIFF
--- a/dbt/moz_social/dbt_project.yml
+++ b/dbt/moz_social/dbt_project.yml
@@ -35,3 +35,5 @@ models:
     # Config indicated by + and applies to all files under models/example/
     example:
       +materialized: view
+    mozsocial_analytics_dev:
+      +materialized: view

--- a/dbt/moz_social/models/mozsocial_analytics_dev/activity_first_2_weeks.sql
+++ b/dbt/moz_social/models/mozsocial_analytics_dev/activity_first_2_weeks.sql
@@ -1,0 +1,73 @@
+{{ config(
+    materialized='table'
+)}}
+
+SELECT
+  a.id AS account_id,
+  a.created_at AS account_created_at,
+  COUNT(DISTINCT
+    CASE
+      WHEN TIMESTAMP_DIFF(s.created_at, a.created_at, DAY) BETWEEN 0 AND 6 THEN s.id
+  END
+    ) AS week_1_status_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN TIMESTAMP_DIFF(fa.created_at, a.created_at, DAY) BETWEEN 0 AND 6 THEN fa.id
+  END
+    ) AS week_1_favorite_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN TIMESTAMP_DIFF(fo.created_at, a.created_at, DAY) BETWEEN 0 AND 6 THEN fo.id
+  END
+    ) AS week_1_follow_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN TIMESTAMP_DIFF(s.created_at, a.created_at, DAY) BETWEEN 7 AND 13 THEN s.id
+  END
+    ) AS week_2_status_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN TIMESTAMP_DIFF(fa.created_at, a.created_at, DAY) BETWEEN 7 AND 13 THEN fa.id
+  END
+    ) AS week_2_favorite_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN TIMESTAMP_DIFF(fo.created_at, a.created_at, DAY) BETWEEN 7 AND 13 THEN fo.id
+  END
+    ) AS week_2_follow_count
+  --start with accounts
+FROM
+  `moz-fx-moztodon-prod.public.accounts` AS a
+  --join against statuses (posts)
+LEFT JOIN
+  `moz-fx-moztodon-prod.public.statuses` AS s
+ON
+  a.id = s.account_id
+  --first two weeks since account creation
+  AND TIMESTAMP_DIFF(s.created_at, a.created_at, DAY) BETWEEN 0
+  AND 13
+  --join against favoriting (liking) a post
+LEFT JOIN
+  `moz-fx-moztodon-prod.public.favourites` AS fa
+ON
+  a.id = fa.account_id
+  --first two weeks since account creation
+  AND TIMESTAMP_DIFF(fa.created_at, a.created_at, DAY) BETWEEN 0
+  AND 13
+  --join against following an account
+LEFT JOIN
+  `moz-fx-moztodon-prod.public.follows` AS fo
+ON
+  a.id = fo.account_id
+  --first two weeks since account creation
+  AND TIMESTAMP_DIFF(fo.created_at, a.created_at, DAY) BETWEEN 0
+  AND 13
+  --null domain corresponds to mozilla.social accounts
+WHERE
+  a.domain IS NULL
+  --there are also NULL and Application values for the actor_type field
+  --excluding them for now
+  AND (a.actor_type = 'Person' OR a.actor_type IS NULL)
+GROUP BY
+  1,
+  2;

--- a/dbt/moz_social/models/mozsocial_analytics_dev/activity_first_2_weeks.sql
+++ b/dbt/moz_social/models/mozsocial_analytics_dev/activity_first_2_weeks.sql
@@ -70,4 +70,4 @@ WHERE
   AND (a.actor_type = 'Person' OR a.actor_type IS NULL)
 GROUP BY
   1,
-  2;
+  2

--- a/dbt/moz_social/models/mozsocial_analytics_dev/activity_first_2_weeks.yml
+++ b/dbt/moz_social/models/mozsocial_analytics_dev/activity_first_2_weeks.yml
@@ -1,0 +1,47 @@
+version: 2
+
+models:
+  - name: activity_first_2_weeks
+    description: "Counts related to a user's activity within the first two weeks of account creation."
+    columns:
+      - name: account_id 
+        description: "Unique identifier of an account."
+        tests:
+          - unique
+          - not_null
+
+      - name: account_created_at
+        description: "The day and time that the account was created."
+        tests:
+          - not_null 
+
+      - name: week_1_status_count
+        description: "Counts the number of times this user shared a status in the first 7 days after account creation."
+        tests: 
+          - not_null 
+
+      - name: week_1_favorite_count
+        description: "Counts the number of times this user favorited a status in the first week after account creation."
+        tests:
+          - not_null 
+
+      - name: week_1_follow_count
+        description: "Counts the number of times this user followed an account in the first week after account creation."
+        tests:
+          - not_null 
+
+      - name: week_2_status_count
+        description: "Counts the number of times this user shared a status in the second week after account creation."
+        tests: 
+          - not_null 
+
+      - name: week_2_favorite_count
+        description: "Counts the number of times this user favorited a status in the second week after account creation."
+        tests:
+          - not_null 
+
+      - name: week_2_follow_count
+        description: "Counts the number of times this user followed an account in the second week after account creation."
+        tests:
+          - not_null 
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = ""
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-packages = [{include = "moz_social_analytics_demo"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
Summary:
For hack week, we want to be able to build a dashboard/report from user data. This creates a table that counts user activity over the first two weeks since account creation. 